### PR TITLE
main: display only requested tasklist

### DIFF
--- a/tasky.py
+++ b/tasky.py
@@ -517,7 +517,14 @@ def main(args):
       if FLAGS.summary:
         tasky.PrintSummary()
       else:
-        tasky.PrintAllTaskLists()
+        if FLAGS['tasklist'].present:
+          tasklistId = tasky.taskLists.keys()[FLAGS.tasklist]
+          if FLAGS.summary:
+            tasky.PrintAllTasks(FLAGS.tasklist, tasklistId, onlySummary=True)
+          else:
+            tasky.PrintAllTasks(FLAGS.tasklist, tasklistId)
+        else:
+          tasky.PrintAllTaskLists()
   else:
     ReadLoop(tasky, args)
 


### PR DESCRIPTION
If the previous command wasn't a list operation, the default behaviour is
to run a list after performing the requested action (eg. toggle status).
If the previous command specified a task list, however, we should only
re-display the list that has been acted upon.

Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>